### PR TITLE
Fix file picker crash on linux

### DIFF
--- a/desktop/app/build.gradle.kts
+++ b/desktop/app/build.gradle.kts
@@ -103,6 +103,10 @@ compose {
             nativeDistributions {
                 modules("java.instrument", "jdk.unsupported")
                 targetFormats(TargetFormat.Msi, TargetFormat.Deb)
+                if (Platform.getCurrentPlatform() == Platform.Desktop.Linux) {
+                    // filekit library requires this module in linux.
+                    modules("jdk.security.auth")
+                }
                 packageVersion = getAppVersionStringForPackaging()
                 packageName = getAppName()
                 vendor = "abdownloadmanager.com"


### PR DESCRIPTION
acording to https://github.com/vinceglb/FileKit/issues/107 we need to add `jdk.security.auth` module. in linux

### Fixed

- Opening File picker in Linux cause the app to crash
