### PR TITLE
Support mac OS binary release for CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,10 @@
+name: Publish
+
 on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
-
 
 permissions:
   contents: write
@@ -12,7 +13,7 @@ jobs:
   create-packages:
     strategy:
       matrix:
-        os: [ "ubuntu-latest" , "windows-latest" ]
+        os: [ "ubuntu-latest", "windows-latest","macos-latest", "macos-13"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -23,30 +24,70 @@ jobs:
           set -Eeuo pipefail
           jdksPath="$HOME/.jdks"
           os=$(echo "${{ runner.os }}-${{ runner.arch }}" | tr "[:upper:]" "[:lower:]")
-          jdkFileName="jbrsdk_jcef-17.0.10-$os-b1207.14"
-          jdkFileNameWithExt="$jdkFileName.tar.gz"
-          link="https://cache-redirector.jetbrains.com/intellij-jbr/$jdkFileNameWithExt"
-          curl --location "$link" --create-dirs --output "$jdksPath/$jdkFileNameWithExt"
-          tar -xf "$jdksPath/$jdkFileNameWithExt" -C "$jdksPath"
-          echo "JAVA_HOME=$jdksPath/$jdkFileName" >> "$GITHUB_ENV"
-          echo "PATH=$jdksPath/$jdkFileName/bin:$PATH" >> "$GITHUB_ENV"
+          echo "RUNNER_OS=$os" >> "$GITHUB_ENV"
+          
+          version="17.0.10"
+          build="b1207.14"
+          base_file_name="jbrsdk_jcef"
+          file_extension=".tar.gz"
+          
+          download_links=(
+            "linux-arm64 ${base_file_name}-${version}-linux-aarch64-${build}${file_extension}"
+            "linux-x64 ${base_file_name}-${version}-linux-x64-${build}${file_extension}"
+            "macos-arm64 ${base_file_name}-${version}-osx-aarch64-${build}${file_extension}"
+            "macos-x64 ${base_file_name}-${version}-osx-x64-${build}${file_extension}"
+            "windows-arm64 ${base_file_name}-${version}-windows-aarch64-${build}${file_extension}"
+            "windows-x64 ${base_file_name}-${version}-windows-x64-${build}${file_extension}"
+          )
+          
+          found_link=false
+          jdkFileNameWithExt=""
+          jdkFileName=""
+          
+          for link_info in "${download_links[@]}"; do
+            current_os=$(echo "$link_info" | awk '{print $1}')
+            current_link=$(echo "$link_info" | awk '{print $2}')
+            if [ "$current_os" = "$os" ]; then
+              found_link=true
+              jdkFileNameWithExt="$current_link"
+              jdkFileName="${jdkFileNameWithExt%$file_extension}"
+              break
+            fi
+          done
+          
+          echo $jdkFileNameWithExt
+          echo $jdkFileName
+          
+          if [ "$found_link" = true ]; then
+            link="https://cache-redirector.jetbrains.com/intellij-jbr/$jdkFileNameWithExt"
+            curl --location "$link" --create-dirs --output "$jdksPath/$jdkFileNameWithExt"
+            tar -xf "$jdksPath/$jdkFileNameWithExt" -C "$jdksPath"
+            echo "JAVA_HOME=$jdksPath/$jdkFileName" >> "$GITHUB_ENV"
+            if [[ "$os" == *"macos"* ]]; then
+            echo "JAVA_HOME=$jdksPath/$jdkFileName/Contents/Home" >> "$GITHUB_ENV"
+            fi
+            echo "PATH=$jdksPath/$jdkFileName/bin:$PATH" >> "$GITHUB_ENV"
+          else
+            echo "Can not find $os download link, exit"
+            exit 1
+          fi
       - name: Cache Gradle Dependencies
         uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ matrix.os }}-gradle
+          key: ${{ env.RUNNER_OS }}-gradle
           enableCrossOsArchive: true
       - name: make Gradlew executable
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os != 'windows-latest'
         run: |
           chmod 755 ./gradlew
         shell: "bash"
       - name: Gradle
-#          at the current version of compose plugin
-#          first attempt to init gradle always fails because of "BuildScopeServices has been closed"
-#          remove this after this bug is fixed
+        #          at the current version of compose plugin
+        #          first attempt to init gradle always fails because of "BuildScopeServices has been closed"
+        #          remove this after this bug is fixed
         continue-on-error: true
         run: |
           ./gradlew
@@ -66,11 +107,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ./build/ci-release
-          name: app-${{ matrix.os }}
+          name: app-${{ env.RUNNER_OS }}
 
   release:
     runs-on: "ubuntu-latest"
-    needs: ["create-packages"]
+    needs: [ "create-packages" ]
     steps:
       - uses: "actions/download-artifact@v4"
         name: "Download All Artifacts Into One Directory"
@@ -90,7 +131,7 @@ jobs:
           tree .
       - uses: softprops/action-gh-release@v2
         with:
-          prerelease: ${{ !steps.version.outputs.is_stable }}
+          prerelease: ${{!steps.version.outputs.is_stable }}
           make_latest: legacy
           draft: true
           files: |

--- a/buildSrc/src/main/kotlin/buildlogic/CiUtils.kt
+++ b/buildSrc/src/main/kotlin/buildlogic/CiUtils.kt
@@ -9,6 +9,7 @@ import java.io.File
 object CiUtils {
     fun getTargetFileName(
         packageName: String,
+        systemArch: String,
         appVersion: Version,
         target: InstallerTargetFormat?,
     ): String {
@@ -35,7 +36,7 @@ object CiUtils {
                 }
             }
         }.name.lowercase()
-        return "${packageName}_${appVersion}_${platformName}.${fileExtension}"
+        return "${packageName}_${appVersion}_${platformName}_${systemArch}.${fileExtension}"
     }
 
     fun getFileOfPackagedTarget(
@@ -89,6 +90,7 @@ object CiUtils {
     fun movePackagedAndCreateSignature(
         appVersion: Version,
         packageName: String,
+        systemArch: String,
         target: InstallerTargetFormat,
         basePackagedAppsDir: File,
         outputDir: File,
@@ -106,7 +108,7 @@ object CiUtils {
             target = target
         )
 
-        val newName = getTargetFileName(packageName, appVersion, target)
+        val newName = getTargetFileName(packageName, systemArch, appVersion, target)
         copyAndHashToDestination(
             src = exeFile,
             destinationFolder = outputDir,

--- a/desktop/app/build.gradle.kts
+++ b/desktop/app/build.gradle.kts
@@ -5,6 +5,9 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import ir.amirab.util.platform.Platform
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat.*
+import java.lang.System.getProperty
+
+
 
 plugins {
     id(MyPlugins.kotlin)
@@ -84,6 +87,7 @@ tasks.processResources {
 }
 
 val desktopPackageName = "com.abdownloadmanager.desktop"
+val systemArch = getProperty("os.arch")
 compose {
     desktop {
         application {
@@ -296,6 +300,7 @@ val createBinariesForCi by tasks.registering {
                 CiUtils.movePackagedAndCreateSignature(
                     getAppVersion(),
                     packageName,
+                    systemArch,
                     target,
                     installerPlugin.outputFolder.get().asFile,
                     output,
@@ -312,6 +317,7 @@ val createBinariesForCi by tasks.registering {
                 CiUtils.movePackagedAndCreateSignature(
                     getAppVersion(),
                     packageName,
+                    systemArch,
                     target,
                     mainRelease.get().asFile.resolve(target.outputDirName),
                     output,
@@ -329,6 +335,7 @@ val createBinariesForCi by tasks.registering {
             output,
             CiUtils.getTargetFileName(
                 packageName,
+                systemArch,
                 getAppVersion(),
                 null, // this is not an installer (it will be automatically converted to current os name
             )


### PR DESCRIPTION
### Description

#### Summary
This PR adds macOS platform support to our CI. It modifies key files for smooth macOS builds and releases.

#### Changes Made
- **`.github/workflows/publish.yml`**:
    - Added macOS entries to the `os` matrix.
    - Adjusted JDK download, caching, and Gradlew steps for macOS.
- **`buildSrc/src/main/kotlin/buildlogic/CiUtils.kt`**: Updated functions to handle macOS architecture for file naming.
- **`desktop/app/build.gradle.kts`**: Added code to work with macOS architecture in packaging.

### Example 
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/1c6905c3-4fe5-4693-8504-b27211328ae6">

### Test locally
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/6d185350-e826-4dc3-b992-d0494b4c0883">
