### PR TITLE
fix tray name on linux

### DIFF
--- a/desktop/tray/linux/src/main/kotlin/ir/amirab/util/desktop/systemtray/impl/ComposeSystemTrayForLinux.kt
+++ b/desktop/tray/linux/src/main/kotlin/ir/amirab/util/desktop/systemtray/impl/ComposeSystemTrayForLinux.kt
@@ -23,7 +23,8 @@ class ComposeSystemTrayForLinux : IComposeSystemTray {
         menu: List<MenuItem>,
         onClick: () -> Unit
     ) {
-        val systemTray: SystemTray? = remember { SystemTray.get() }
+        val tooltipString = tooltip.rememberString()
+        val systemTray: SystemTray? = remember { SystemTray.get(tooltipString) }
         if (systemTray == null) {
             System.err.println("System tray is not supported")
             return
@@ -36,7 +37,6 @@ class ComposeSystemTrayForLinux : IComposeSystemTray {
                 GlobalLayoutDirection,
             )
         }
-        val tooltipString = tooltip.rememberString()
 
         LaunchedEffect(awtImage) {
             systemTray.setImage(awtImage)


### PR DESCRIPTION
before:
<img width="201" alt="image" src="https://github.com/user-attachments/assets/7c6e87b9-4c77-496c-a120-faaf683a4ded" />
after:
<img width="156" alt="image" src="https://github.com/user-attachments/assets/b7261d81-fdf1-45a7-b1ef-d7930d3232b6" />
