### PR TITLE
allow app to be full portable

### DIFF
--- a/desktop/app/build.gradle.kts
+++ b/desktop/app/build.gradle.kts
@@ -188,6 +188,10 @@ buildConfig {
         provider { getPrettifiedAppName() }
     )
     buildConfigField(
+        "DATA_DIR_NAME",
+        provider { ".abdm" }
+    )
+    buildConfigField(
         "APP_VERSION",
         provider { getAppVersionString() }
     )

--- a/desktop/app/resources/common/app.properties
+++ b/desktop/app/resources/common/app.properties
@@ -1,3 +1,1 @@
-app.config.path="${user.home}/.abdm/config"
-app.system.path="${user.home}/.abdm/system"
 app.debug="false"

--- a/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/SharedConstants.kt
+++ b/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/SharedConstants.kt
@@ -8,6 +8,7 @@ object SharedConstants : BaseConstants {
     override val appName: String = BuildConfig.APP_NAME
     override val appDisplayName: String = BuildConfig.APP_DISPLAY_NAME
     override val packageName: String = BuildConfig.PACKAGE_NAME
+    override val dataDirName: String = BuildConfig.DATA_DIR_NAME
     override val projectWebsite: String = BuildConfig.PROJECT_WEBSITE
     override val projectTranslations: String = BuildConfig.PROJECT_TRANSLATIONS
     override val projectSourceCode: String = BuildConfig.PROJECT_SOURCE_CODE

--- a/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/utils/AppInfo.kt
+++ b/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/utils/AppInfo.kt
@@ -34,6 +34,26 @@ object AppInfo {
                 }?.path
             }
     }
+
+    private fun getPortableDataDir(): File? {
+        val dataDirName = SharedConstants.dataDirName
+        if (installationFolder != null) {
+            val portableDataDir = File(installationFolder, dataDirName)
+            if (portableDataDir.exists() && portableDataDir.canWrite()) {
+                return portableDataDir
+            }
+        }
+        return null
+    }
+
+    private fun getUserDataDir(): File {
+        val dataDirName = SharedConstants.dataDirName
+        return File(System.getProperty("user.home"), dataDirName)
+    }
+
+    val dataDir by lazy {
+        getPortableDataDir() ?: getUserDataDir()
+    }
 }
 
 fun AppInfo.isAppInstalled(): Boolean {
@@ -48,12 +68,9 @@ fun AppInfo.isInDebugMode(): Boolean {
     return AppArguments.get().debug || AppProperties.isDebugMode() || isInIDE()
 }
 
-val AppInfo.configDir: File get() = File(AppProperties.getConfigDirectory())
-val AppInfo.systemDir: File get() = File(AppProperties.getSystemDirectory())
+val AppInfo.configDir: File get() = dataDir.resolve("config")
+val AppInfo.systemDir: File get() = dataDir.resolve("system")
 val AppInfo.updateDir: File get() = AppInfo.systemDir.resolve("update")
 val AppInfo.logDir: File get() = AppInfo.systemDir.resolve("log")
 val AppInfo.optionsDir: File get() = AppInfo.configDir.resolve("options")
 val AppInfo.downloadDbDir: File get() = AppInfo.configDir.resolve("download_db")
-fun AppInfo.extensions() {
-
-}

--- a/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/utils/AppProperties.kt
+++ b/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/utils/AppProperties.kt
@@ -19,8 +19,6 @@ object AppProperties {
     }
 
     private object Keys {
-        const val CONFIG_DIRECTORY: String = "app.config.path"
-        const val SYSTEM_DIRECTORY: String = "app.system.path"
         const val DEBUG: String = "app.debug"
     }
 
@@ -78,15 +76,6 @@ object AppProperties {
             .toBoolean()
     }
 
-    fun getConfigDirectory(): String {
-        return ensureAndGet(Keys.CONFIG_DIRECTORY)
-            .toString()
-    }
-
-    fun getSystemDirectory(): String {
-        return ensureAndGet(Keys.SYSTEM_DIRECTORY)
-            .toString()
-    }
     //app.properties in installation directory
     fun isAppPropertiesFound(): Boolean {
         return foundAppProperties

--- a/desktop/app/src/main/resources/configs/app_default.properties
+++ b/desktop/app/src/main/resources/configs/app_default.properties
@@ -1,3 +1,1 @@
-app.config.path="${user.home}/.abdm/config"
-app.system.path="${user.home}/.abdm/system"
 app.debug="false"

--- a/shared/app-utils/src/main/kotlin/com/abdownloadmanager/shared/utils/BaseConstants.kt
+++ b/shared/app-utils/src/main/kotlin/com/abdownloadmanager/shared/utils/BaseConstants.kt
@@ -4,6 +4,7 @@ interface BaseConstants {
     val appName: String
     val appDisplayName: String
     val packageName: String
+    val dataDirName: String
     val projectWebsite: String
     val projectSourceCode: String
     val projectTranslations: String


### PR DESCRIPTION
In order to enable it create an empty directory `.abdm` in  the installation directory