### PR TITLE
Add macOS settings menu handler with callback

### DIFF
--- a/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/ui/Ui.kt
+++ b/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/ui/Ui.kt
@@ -71,7 +71,8 @@ object Ui : KoinComponent {
                 onClickIcon = appComponent::activateHomeIfNotOpen,
                 onAboutClick = {
                     appComponent.showAboutPage.value = true
-                }
+                },
+                onSettingsClick = appComponent::openSettings
             )
         }
         application {
@@ -87,23 +88,28 @@ object Ui : KoinComponent {
                                 ProvideSizeUnits(appComponent) {
                                     HandleEffectsForApp(appComponent)
                                     SystemTray(appComponent)
-                                    val showHomeSlot = appComponent.showHomeSlot.collectAsState().value
+                                    val showHomeSlot =
+                                        appComponent.showHomeSlot.collectAsState().value
                                     showHomeSlot.child?.instance?.let {
                                         HomeWindow(it, appComponent::closeHome)
                                     }
-                                    val showSettingSlot = appComponent.showSettingSlot.collectAsState().value
+                                    val showSettingSlot =
+                                        appComponent.showSettingSlot.collectAsState().value
                                     showSettingSlot.child?.instance?.let {
                                         SettingWindow(it, appComponent::closeSettings)
                                     }
-                                    val showQueuesSlot = appComponent.showQueuesSlot.collectAsState().value
+                                    val showQueuesSlot =
+                                        appComponent.showQueuesSlot.collectAsState().value
                                     showQueuesSlot.child?.instance?.let {
                                         QueuesWindow(it)
                                     }
-                                    val batchDownloadSlot = appComponent.batchDownloadSlot.collectAsState().value
+                                    val batchDownloadSlot =
+                                        appComponent.batchDownloadSlot.collectAsState().value
                                     batchDownloadSlot.child?.instance?.let {
                                         BatchDownloadWindow(it)
                                     }
-                                    val editDownloadSlot = appComponent.editDownloadSlot.collectAsState().value
+                                    val editDownloadSlot =
+                                        appComponent.editDownloadSlot.collectAsState().value
                                     editDownloadSlot.child?.instance?.let {
                                         EditDownloadWindow(it)
                                     }

--- a/desktop/mac_utils/src/main/kotlin/ir/amirab/util/desktop/mac/event/MacEventHandler.kt
+++ b/desktop/mac_utils/src/main/kotlin/ir/amirab/util/desktop/mac/event/MacEventHandler.kt
@@ -5,8 +5,14 @@ import java.awt.desktop.AppReopenedEvent
 import java.awt.desktop.AppReopenedListener
 
 object MacEventHandler {
-    fun configure(onClickIcon: () -> Unit, onAboutClick: () -> Unit) {
-        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.APP_EVENT_REOPENED)) {
+    fun configure(
+        onClickIcon: () -> Unit,
+        onAboutClick: () -> Unit,
+        onSettingsClick: () -> Unit
+    ) {
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop()
+                .isSupported(Desktop.Action.APP_EVENT_REOPENED)
+        ) {
             Desktop.getDesktop().apply {
                 addAppEventListener(object : AppReopenedListener {
                     override fun appReopened(e: AppReopenedEvent?) {
@@ -15,6 +21,9 @@ object MacEventHandler {
                 })
                 if (isSupported(Desktop.Action.APP_ABOUT)) {
                     setAboutHandler { onAboutClick.invoke() }
+                }
+                if (isSupported(Desktop.Action.APP_PREFERENCES)) {
+                    setPreferencesHandler { onSettingsClick.invoke() }
                 }
             }
         }


### PR DESCRIPTION
Adds support for macOS Settings menu via setPreferencesHandler. Triggered when user selects "Settings" or presses Cmd + , by default.