### PR TITLE
Add macOS App Window Focus Utility

### DIFF
--- a/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/pages/addDownload/ShowAddDownloadDialogs.kt
+++ b/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/pages/addDownload/ShowAddDownloadDialogs.kt
@@ -1,14 +1,5 @@
 package com.abdownloadmanager.desktop.pages.addDownload
 
-import com.abdownloadmanager.desktop.AddDownloadDialogManager
-import com.abdownloadmanager.desktop.pages.addDownload.multiple.AddMultiDownloadComponent
-import com.abdownloadmanager.desktop.pages.addDownload.multiple.AddMultiItemPage
-import com.abdownloadmanager.desktop.pages.addDownload.single.AddDownloadPage
-import com.abdownloadmanager.desktop.pages.addDownload.single.AddSingleDownloadComponent
-import com.abdownloadmanager.desktop.window.custom.CustomWindow
-import com.abdownloadmanager.desktop.window.custom.WindowIcon
-import com.abdownloadmanager.desktop.window.custom.WindowTitle
-import com.abdownloadmanager.shared.utils.ui.icon.MyIcons
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -19,9 +10,19 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
-import com.abdownloadmanager.shared.utils.ui.theme.LocalUiScale
+import com.abdownloadmanager.desktop.AddDownloadDialogManager
+import com.abdownloadmanager.desktop.pages.addDownload.multiple.AddMultiDownloadComponent
+import com.abdownloadmanager.desktop.pages.addDownload.multiple.AddMultiItemPage
+import com.abdownloadmanager.desktop.pages.addDownload.single.AddDownloadPage
+import com.abdownloadmanager.desktop.pages.addDownload.single.AddSingleDownloadComponent
+import com.abdownloadmanager.desktop.window.custom.CustomWindow
+import com.abdownloadmanager.desktop.window.custom.WindowIcon
+import com.abdownloadmanager.desktop.window.custom.WindowTitle
 import com.abdownloadmanager.resources.Res
+import com.abdownloadmanager.shared.utils.ui.icon.MyIcons
+import com.abdownloadmanager.shared.utils.ui.theme.LocalUiScale
 import ir.amirab.util.compose.resources.myStringResource
+import ir.amirab.util.desktop.PlatformAppActivator
 import ir.amirab.util.desktop.screen.applyUiScale
 import java.awt.Dimension
 
@@ -58,6 +59,7 @@ fun ShowAddDownloadDialogs(component: AddDownloadDialogManager) {
                 ) {
                     LaunchedEffect(Unit) {
                         window.minimumSize = Dimension(w, h)
+                        PlatformAppActivator.active()
                     }
 //                    BringToFront()
                     WindowTitle(myStringResource(Res.string.add_download))
@@ -81,6 +83,7 @@ fun ShowAddDownloadDialogs(component: AddDownloadDialogManager) {
                 ) {
                     LaunchedEffect(Unit) {
                         window.minimumSize = Dimension(w, h)
+                        PlatformAppActivator.active()
                     }
 //                    BringToFront()
                     WindowTitle(myStringResource(Res.string.add_download))

--- a/desktop/shared/build.gradle.kts
+++ b/desktop/shared/build.gradle.kts
@@ -1,9 +1,13 @@
-plugins{
+plugins {
     id(MyPlugins.kotlin)
     id(MyPlugins.composeDesktop)
 }
 
 dependencies {
+    // Jna
+    implementation(libs.jna.core)
+    implementation(libs.jna.platform)
+
     implementation(project(":shared:app"))
     implementation(project(":shared:app-utils"))
     implementation(project(":shared:utils"))

--- a/desktop/shared/build.gradle.kts
+++ b/desktop/shared/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 dependencies {
     // Jna
     implementation(libs.jna.core)
-    implementation(libs.jna.platform)
 
     implementation(project(":shared:app"))
     implementation(project(":shared:app-utils"))

--- a/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/DesktopUtils.kt
+++ b/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/DesktopUtils.kt
@@ -1,8 +1,8 @@
 package ir.amirab.util.desktop
 
-import ir.amirab.util.desktop.linux.LinuxUtils
-import ir.amirab.util.desktop.mac.MacOSUtils
-import ir.amirab.util.desktop.windows.WindowsUtils
+import ir.amirab.util.desktop.utils.linux.LinuxUtils
+import ir.amirab.util.desktop.utils.mac.MacOSUtils
+import ir.amirab.util.desktop.utils.windows.WindowsUtils
 import ir.amirab.util.platform.Platform
 
 

--- a/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/PlatformAppActivator.kt
+++ b/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/PlatformAppActivator.kt
@@ -1,0 +1,21 @@
+package ir.amirab.util.desktop
+
+import ir.amirab.util.desktop.activator.mac.MacAppActivator
+import ir.amirab.util.platform.Platform
+
+interface PlatformAppActivator {
+    fun active()
+
+    companion object : PlatformAppActivator by getPlatformAppActivatorForCurrentOs()
+}
+
+object EmptyAppActivator : PlatformAppActivator {
+    override fun active() {
+        // Nothing
+    }
+}
+
+private fun getPlatformAppActivatorForCurrentOs() = when (Platform.getCurrentPlatform()) {
+    Platform.Desktop.MacOS -> MacAppActivator
+    else -> EmptyAppActivator
+}

--- a/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/activator/mac/Foundation.kt
+++ b/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/activator/mac/Foundation.kt
@@ -1,0 +1,11 @@
+package ir.amirab.util.desktop.activator.mac
+
+import com.sun.jna.Library
+import com.sun.jna.Pointer
+
+interface Foundation : Library {
+    fun objc_getClass(name: String): Pointer
+    fun sel_registerName(name: String): Pointer
+    fun objc_msgSend(receiver: Pointer, selector: Pointer): Pointer
+    fun objc_msgSend(receiver: Pointer, selector: Pointer, b: Boolean): Pointer
+}

--- a/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/activator/mac/MacAppActivator.kt
+++ b/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/activator/mac/MacAppActivator.kt
@@ -1,0 +1,22 @@
+package ir.amirab.util.desktop.activator.mac
+
+import com.sun.jna.Native
+import ir.amirab.util.desktop.PlatformAppActivator
+
+object MacAppActivator : PlatformAppActivator {
+    private val foundation by lazy {
+        runCatching { Native.load("objc", Foundation::class.java) }.getOrNull()
+    }
+
+    override fun active() {
+        val requiredFoundation = foundation ?: return
+        runCatching {
+            val nsAppClass = requiredFoundation.objc_getClass("NSApplication")
+            val sharedAppSel = requiredFoundation.sel_registerName("sharedApplication")
+            val activateSel = requiredFoundation.sel_registerName("activateIgnoringOtherApps:")
+
+            val nsApp = requiredFoundation.objc_msgSend(nsAppClass, sharedAppSel)
+            requiredFoundation.objc_msgSend(nsApp, activateSel, true)
+        }
+    }
+}

--- a/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/utils/linux/LinuxUtils.kt
+++ b/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/utils/linux/LinuxUtils.kt
@@ -1,4 +1,4 @@
-package ir.amirab.util.desktop.linux
+package ir.amirab.util.desktop.utils.linux
 
 import ir.amirab.util.desktop.DesktopUtils
 import ir.amirab.util.execAndWait

--- a/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/utils/mac/MacOSUtils.kt
+++ b/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/utils/mac/MacOSUtils.kt
@@ -1,4 +1,4 @@
-package ir.amirab.util.desktop.mac
+package ir.amirab.util.desktop.utils.mac
 
 import ir.amirab.util.desktop.DesktopUtils
 import ir.amirab.util.execAndWait

--- a/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/utils/windows/WindowsUtils.kt
+++ b/desktop/shared/src/main/kotlin/ir/amirab/util/desktop/utils/windows/WindowsUtils.kt
@@ -1,4 +1,4 @@
-package ir.amirab.util.desktop.windows
+package ir.amirab.util.desktop.utils.windows
 
 import ir.amirab.util.desktop.DesktopUtils
 import ir.amirab.util.execAndWait


### PR DESCRIPTION
This PR introduces a utility that ensures the app window comes to the front and gains focus when needed, specifically on macOS. It makes sure the app gets activated even if it's running on a different desktop (Space) and brings its window to the foreground, while ignoring other applications.

I’ve implemented this for macOS only, as it focuses the app window when needed. I’m not sure if this is necessary for other platforms, but it works on macOS as expected.

This can probably be achieved through browser integration as well, but this approach works fine.