### PR TITLE
fix some links not captured correctly

### DIFF
--- a/shared/utils/src/main/kotlin/ir/amirab/util/UrlUtils.kt
+++ b/shared/utils/src/main/kotlin/ir/amirab/util/UrlUtils.kt
@@ -1,12 +1,12 @@
 package ir.amirab.util
 
-import java.net.URI
-import java.net.URL
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.net.URLDecoder
 
 object UrlUtils {
-    fun createURL(url: String): URL {
-        return URI.create(url).toURL()
+    fun createURL(url: String): HttpUrl {
+        return url.toHttpUrl()
     }
 
     fun isValidUrl(link: String): Boolean {
@@ -17,8 +17,7 @@ object UrlUtils {
         return runCatching {
             createURL(link)
         }.map { url ->
-            val foundName = url.path
-                .split("/")
+            val foundName = url.pathSegments
                 .lastOrNull { it.isNotBlank() }
                 ?.let {
                     kotlin.runCatching {


### PR DESCRIPTION
some not well encoded URLs not captured correctly. for example "https://example.com/some-[file].mp4"