### PR TITLE
Modified categorization behaviour

### DIFF
--- a/shared/app-utils/src/main/kotlin/com/abdownloadmanager/shared/utils/category/Category.kt
+++ b/shared/app-utils/src/main/kotlin/com/abdownloadmanager/shared/utils/category/Category.kt
@@ -40,6 +40,7 @@ data class Category(
     val hasUrlPattern = acceptedUrlPatterns.isNotEmpty()
 
     fun acceptFileName(fileName: String): Boolean {
+        if (acceptedFileTypes.any { it == "*" || it == "*.*" }) return true
         return acceptedFileTypes.any { ext ->
             fileName.endsWith(
                 suffix = ".$ext",

--- a/shared/app-utils/src/main/kotlin/com/abdownloadmanager/shared/utils/category/CategoryManager.kt
+++ b/shared/app-utils/src/main/kotlin/com/abdownloadmanager/shared/utils/category/CategoryManager.kt
@@ -83,12 +83,12 @@ class CategoryManager(
         val fileName = categoryItem.fileName
         return getCategories()
             .filter {
+                it.acceptFileName(fileName) || it.acceptUrl(url)
+            }.sortedWith(compareByDescending<Category> {
                 it.acceptFileName(fileName)
-            }.sortedByDescending {
-                it.hasUrlPattern
-            }.firstOrNull {
-                it.acceptUrl(url)
-            }
+            }.thenByDescending {
+                it.hasUrlPattern && it.acceptUrl(url)
+            }).firstOrNull()
 
     }
 


### PR DESCRIPTION
Made the automatic categorization accept wildcards with "`*`" and "`*.*`", making it possible for users to categorize any file coming from a certain URL into desired folders without requiring specific file types to be defined. This overall allows for finer categorization when downloading files of the same file types from different sites across the web, eliminating the need for moving these files manually to where they are supposed to be.

It was also necessary to change the sorting acceptance logic, as the categorizer would skip URL patterns if file types were left undefined.