### PR TITLE
Add Nix flake support (Packaging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,76 @@ winget install amir1376.ABDownloadManager
 scoop install extras/abdownloadmanager
 ```
 
+#### Install on NixOS
+
+You can install AB Download Manager on NixOS by adding the community flake to your system configuration.
+
+**Prerequisites:** You must have [Nix Flakes](https://nixos.wiki/wiki/Flakes) enabled on your NixOS system.
+
+1.  **Add the Flake to your NixOS Configuration**
+
+    In your system's `flake.nix` (usually at `/etc/nixos/flake.nix`), add `ab-download-manager` as an input:
+
+    ```nix
+    # /etc/nixos/flake.nix
+    {
+      inputs = {
+        nixpkgs.url = "github:Nixos/nixpkgs/nixos-unstable";
+        
+        # Add this line
+        ab-download-manager.url = "github:amir1376/ab-download-manager";
+      };
+
+      outputs = { self, nixpkgs, ab-download-manager, ... }: {
+        # ...
+      };
+    }
+    ```
+
+2.  **Add the Package to your System**
+
+    In the same `flake.nix`, pass the package to your modules using `specialArgs`. Then, in your `configuration.nix`, add it to `environment.systemPackages`.
+
+    ```nix
+    # /etc/nixos/flake.nix
+    {
+      # ... inputs from step 1
+      outputs = { self, nixpkgs, ab-download-manager, ... }: {
+        nixosConfigurations."your-hostname" = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          specialArgs = {
+            # Pass the package to configuration.nix
+            ab-download-manager-pkg = ab-download-manager.packages.x86_64-linux.default;
+          };
+          modules = [ ./configuration.nix ];
+        };
+      };
+    }
+    ```
+    
+    Now add the package in your `configuration.nix`:
+    ```nix
+    # /etc/nixos/configuration.nix
+    { config, pkgs, ab-download-manager-pkg, ... }:
+    {
+      environment.systemPackages = [
+        # ... your other packages
+        ab-download-manager-pkg
+      ];
+    }
+    ```
+
+3.  **Rebuild your System**
+
+    Apply the changes with:
+
+    ```bash
+    sudo nixos-rebuild switch --flake /etc/nixos#your-hostname
+    ```
+    *(Replace `your-hostname` with your system's actual hostname)*
+
+    After rebuilding, AB Download Manager will be installed and available in your applications menu.
+
 ### Browser Extensions
 
 You can download the browser extension to integrate the app with your browser.

--- a/README.md
+++ b/README.md
@@ -73,61 +73,25 @@ You can install AB Download Manager on NixOS by adding the community flake to yo
     # /etc/nixos/flake.nix
     {
       inputs = {
-        nixpkgs.url = "github:Nixos/nixpkgs/nixos-unstable";
-        
         # Add this line
         ab-download-manager.url = "github:amir1376/ab-download-manager";
-      };
-
-      outputs = { self, nixpkgs, ab-download-manager, ... }: {
-        # ...
       };
     }
     ```
 
 2.  **Add the Package to your System**
-
-    In the same `flake.nix`, pass the package to your modules using `specialArgs`. Then, in your `configuration.nix`, add it to `environment.systemPackages`.
-
-    ```nix
-    # /etc/nixos/flake.nix
-    {
-      # ... inputs from step 1
-      outputs = { self, nixpkgs, ab-download-manager, ... }: {
-        nixosConfigurations."your-hostname" = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          specialArgs = {
-            # Pass the package to configuration.nix
-            ab-download-manager-pkg = ab-download-manager.packages.x86_64-linux.default;
-          };
-          modules = [ ./configuration.nix ];
-        };
-      };
-    }
-    ```
-    
     Now add the package in your `configuration.nix`:
     ```nix
     # /etc/nixos/configuration.nix
-    { config, pkgs, ab-download-manager-pkg, ... }:
+    { config, pkgs, ab-download-manager, ... }:
     {
       environment.systemPackages = [
         # ... your other packages
-        ab-download-manager-pkg
+        # ab-download-manager.packages.x86_64-linux.default 
+        ab-download-manager.packages."${system}".default
       ];
     }
     ```
-
-3.  **Rebuild your System**
-
-    Apply the changes with:
-
-    ```bash
-    sudo nixos-rebuild switch --flake /etc/nixos#your-hostname
-    ```
-    *(Replace `your-hostname` with your system's actual hostname)*
-
-    After rebuilding, AB Download Manager will be installed and available in your applications menu.
 
 ### Browser Extensions
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753939845,
+        "narHash": "sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1+A4GQej/lBk5y7I=",
+        "owner": "Nixos",
+        "repo": "nixpkgs",
+        "rev": "94def634a20494ee057c76998843c015909d6311",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,138 @@
+{
+  description = "A flake for AB Download Manager";
+  inputs = {
+    nixpkgs.url = "github:Nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        version = "1.6.8";
+        src = pkgs.fetchurl {
+          url = "https://github.com/amir1376/ab-download-manager/releases/download/v${version}/ABDownloadManager_${version}_linux_x64.tar.gz";
+          sha256 = "355be492ca0a4b852da0619782590c6359ff124686fb277a5c30c4452c9b2725";
+        };
+        runtimeDeps = with pkgs; [
+# GUI and windowing
+          gtk3
+          gtk4
+          glib
+          gdk-pixbuf
+          cairo
+          pango
+          atk
+          
+          # X11 and Wayland support
+          xorg.libX11
+          xorg.libXext
+          xorg.libXi
+          xorg.libXrender
+          xorg.libXtst
+          xorg.libXrandr
+          xorg.libXfixes
+          xorg.libXcomposite
+          xorg.libXdamage
+          xorg.libXcursor
+          wayland
+          
+          # Audio and multimedia
+          alsa-lib
+          pulseaudio
+          
+          # System integration
+          libnotify
+          xdg-utils
+          cups
+          dbus
+          systemd
+          
+          # Fonts and rendering
+          fontconfig
+          freetype
+          dejavu_fonts
+          liberation_ttf
+          
+          # OpenGL
+          libGL
+          libGLU
+          mesa
+          
+          # Desktop integration
+          gsettings-desktop-schemas
+          hicolor-icon-theme
+          
+          # Java/JNA native libraries
+          glibc
+          gcc-unwrapped.lib
+          zlib
+          
+          # Additional libraries that might be needed
+          libpng
+          libjpeg
+          expat
+          libffi
+          libuuid
+          nspr
+          nss
+        ];
+        libPath = pkgs.lib.makeLibraryPath runtimeDeps;
+
+        xdgDataDirs = pkgs.lib.makeSearchPathOutput "share" "XDG_DATA_DIRS" runtimeDeps;
+# Comprehensive font configuration
+        fontConf = pkgs.makeFontsConf {
+          fontDirectories = with pkgs; [ 
+            dejavu_fonts 
+            liberation_ttf 
+            freefont_ttf
+            noto-fonts
+            noto-fonts-cjk-sans
+            noto-fonts-emoji
+          ];
+        };
+      in
+      {
+        packages.default = pkgs.stdenv.mkDerivation rec {
+          pname = "ab-download-manager";
+          inherit version src;
+          nativeBuildInputs = [
+            pkgs.makeWrapper
+            pkgs.autoPatchelfHook
+          ];
+          buildInputs = runtimeDeps;
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out
+            tar -xzf ${src} -C $out
+            mv $out/ABDownloadManager/* $out
+            rmdir $out/ABDownloadManager
+            makeWrapper $out/bin/ABDownloadManager $out/bin/ab-download-manager \
+              --set FONTCONFIG_FILE "${fontConf}/etc/fonts/fonts.conf" \
+              --prefix LD_LIBRARY_PATH : "${libPath}" \
+              --prefix XDG_DATA_DIRS : "${xdgDataDirs}:$out/share"
+            mkdir -p $out/share/applications
+            echo "[Desktop Entry]
+            Name=AB Download Manager
+            Comment=Manage and organize your download files better than before
+            GenericName=Downloader
+            Categories=Utility;Network;
+            Exec=ab-download-manager
+            Icon=ab-download-manager
+            Terminal=false
+            Type=Application
+            StartupWMClass=com-abdownloadmanager-desktop-AppKt" > $out/share/applications/ab-download-manager.desktop
+            mkdir -p $out/share/icons/hicolor/scalable/apps
+            cp $out/lib/ABDownloadManager.png $out/share/icons/hicolor/scalable/apps/ab-download-manager.png
+            runHook postInstall
+          '';
+          meta = with pkgs.lib; {
+            description = "A download manager to manage and organize your download files better than before";
+            homepage = "https://github.com/amir1376/ab-download-manager";
+            license = licenses.gpl3;
+            maintainers = with maintainers; [ ];
+            platforms = platforms.linux;
+          };
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -128,7 +128,7 @@
           meta = with pkgs.lib; {
             description = "A download manager to manage and organize your download files better than before";
             homepage = "https://github.com/amir1376/ab-download-manager";
-            license = licenses.gpl3;
+            license = licenses.asl20;
             maintainers = with maintainers; [ ];
             platforms = platforms.linux;
           };


### PR DESCRIPTION
This PR introduces a Nix flake to provide an easy and reproducible way to install and run AB Download Manager on NixOS and other Linux distributions with Nix.

### Key Changes:

*   **`flake.nix`:** Added a new flake that packages the application, handling all its dependencies for a seamless installation.
*   **`README.md`:** Updated the documentation to include a new "Install on NixOS" section with clear, minimal instructions.

This makes the application much more accessible to users in the Nix ecosystem.