### PR TITLE
Update brew-cask-auto-bump workflow

### DIFF
--- a/.github/workflows/brew-cask-auto-bump.yml
+++ b/.github/workflows/brew-cask-auto-bump.yml
@@ -10,11 +10,14 @@ jobs:
     runs-on: macos-latest
     env:
       HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+      CASK_NAME: ab-download-manager
+      TAP_NAME: amir1376/tap
+      GH_REPO: amir1376/homebrew-tap
 
     steps:
       - name: Tap homebrew cask repo
         run: |
-          brew tap amir1376/tap
+          brew tap ${{ env.TAP_NAME }}
 
       - name: Extract version
         id: ver
@@ -27,7 +30,7 @@ jobs:
             V="$TAG_VER"
           else
             SRC="livecheck"
-            OUT="$(brew livecheck --cask --json amir1376/tap/ab-download-manager || true)"
+            OUT="$(brew livecheck --cask --json ${{ env.TAP_NAME }}/${{ env.CASK_NAME }} || true)"
             V="$(ruby -rjson -e '
               j = JSON.parse(STDIN.read) rescue []
               if j.is_a?(Array) && j[0] && j[0]["version"]
@@ -44,10 +47,24 @@ jobs:
 
       - name: Bump cask
         if: ${{ steps.ver.outputs.version != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
         run: |
+          gh label create "pr-pull" --repo "${{ env.GH_REPO }}" --color "EDEDED" --description "Automatically created for PR labeling" --force || true
           V="${{ steps.ver.outputs.version }}"
-          echo "Bumping ab-download-manager to $V ..."
-          brew bump-cask-pr --no-browse --version "$V" amir1376/tap/ab-download-manager
+          echo "Bumping ${{ env.CASK_NAME }} to $V ..."
+          brew bump-cask-pr --no-browse --version "$V" "${{ env.TAP_NAME }}/${{ env.CASK_NAME }}"
+          sleep 5
+          BRANCH_NAME="bump-${{ env.CASK_NAME }}-$V"
+          echo "Looking for PR from branch: $BRANCH_NAME in repo ${{ env.GH_REPO }}"
+          PR_URL=$(gh pr list --repo "${{ env.GH_REPO }}" --head "$BRANCH_NAME" --state open --json url --jq '.[0].url')
+          if [ -n "$PR_URL" ]; then
+            echo "✅ Found PR: $PR_URL"
+            echo "Adding label 'pr-pull'..."
+            gh pr edit "$PR_URL" --add-label "pr-pull"
+          else
+            echo "⚠️ Could not find the PR for branch $BRANCH_NAME."
+          fi
 
       - name: Skip (No new version)
         if: ${{ steps.ver.outputs.version == '' }}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ winget install amir1376.ABDownloadManager
 scoop install extras/abdownloadmanager
 ```
 
-#### Homebrew (for macOS)
+#### Homebrew (for macOS & Linux)
 
 ```bash
 brew tap amir1376/tap && brew install --cask ab-download-manager
@@ -83,6 +83,10 @@ You can download the browser extension to integrate the app with your browser.
     </picture>
 </a>
 </p>
+
+## Uninstallation
+
+[Uninstall Wiki](https://github.com/amir1376/ab-download-manager/wiki/Uninstall)
 
 ## Screenshots
 


### PR DESCRIPTION
Updated wiki pages:
[Installation.md](https://github.com/user-attachments/files/24277678/Installation.md)
[Uninstall.md](https://github.com/user-attachments/files/24277679/Uninstall.md)

- Add auto-update-brewcask support.
 NEED a new permission in Github Token: **read:org** under **admin:org**
- Add Homebrew cask uninstallation support. ([PR](https://github.com/amir1376/homebrew-tap/pull/3) has been open)
- Add Linux Homebrew support.