### PR TITLE
fix: prioritize suggestedName field sent from integrations/extensions

### DIFF
--- a/shared/app/src/commonMain/kotlin/com/abdownloadmanager/shared/downloaderinui/DownloadUiChecker.kt
+++ b/shared/app/src/commonMain/kotlin/com/abdownloadmanager/shared/downloaderinui/DownloadUiChecker.kt
@@ -86,9 +86,11 @@ abstract class DownloadUiChecker<
 
 
         linkChecker.suggestedName
-            .onEach {
-                it?.let { name ->
-                    this.name.update { name }
+            .onEach { nameFromServer ->
+                nameFromServer?.let { 
+                    this.name.update { nameFromIntegration ->
+                        if (nameFromIntegration.isEmpty()) nameFromServer else nameFromIntegration
+                    }
                 }
             }.launchIn(scope)
 


### PR DESCRIPTION
## Summary
This PR fixes an issue where the backend currently ignores the `suggestedName` field sent by  from extensions

## The Problem
In `DownloadUiChecker.kt`, the `linkChecker.suggestedName`  currently performs an unconditional update. 

This means that even when the extension made an effort to beautify the filename by scraping page titles, cleaning up URL parameters, or using regex to find the real filename, the backend just throws that away and instead it lets the server headers overwrite everything, sometimes with giberrish names such as "video.html", "remote_control.php", "53938212-720p.mp4", forcing the user to rename the files manually.

##   Enabling Smart Filenames
The extension already [has the infrastructure](https://github.com/amir1376/ab-download-manager-browser-integration/blob/a417b3140a5de509a47f367f682a32da94b0beb1/src/linkgrabber/DownloadLinkInterceptor.ts#L222) for `suggestedName`, but the backend was effectively silencing it. 

This change enables that feature, allowing for cleaner filenames from page titles, regex and URL parameters.

## Solution
1) Trust the Integration: if suggestedName is provided via the API, it is preserved and used as the primary filename
2) Fallback: if suggestedName is not provided, the nameFromIntegration is empty, and the backend fallsback to the server side suggestion([which i believe is from the server response](https://github.com/amir1376/ab-download-manager/blob/5ee92ecf4b9014bf2bfa08267eff763849667ea0/shared/app/src/commonMain/kotlin/com/abdownloadmanager/shared/downloaderinui/http/add/HttpLinkChecker.kt#L35))


fixes #905  