### PR TITLE
prevent Win32Exception on startup registry uninstall

### DIFF
--- a/shared/auto-start/src/desktopMain/kotlin/ir/amirab/util/startup/WindowsStartupDesktop.kt
+++ b/shared/auto-start/src/desktopMain/kotlin/ir/amirab/util/startup/WindowsStartupDesktop.kt
@@ -12,12 +12,15 @@ class WindowsStartupDesktop(
     path = path,
     args = args
 ) {
+    private val hKey = WinReg.HKEY_CURRENT_USER
+    private val location = "Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+
     @Throws(Exception::class)
     override fun install() {
         val data = getExecutableWithArgs()
         Advapi32Util.registrySetStringValue(
-            WinReg.HKEY_CURRENT_USER,
-            "Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+            hKey,
+            location,
             this.name,
             data
         )
@@ -25,10 +28,9 @@ class WindowsStartupDesktop(
 
     override fun uninstall() {
         try {
-            val location = "Software\\Microsoft\\Windows\\CurrentVersion\\Run"
-            if (Advapi32Util.registryValueExists(WinReg.HKEY_CURRENT_USER, location, this.name)) {
+            if (Advapi32Util.registryValueExists(hKey, location, this.name)) {
                 Advapi32Util.registryDeleteValue(
-                    WinReg.HKEY_CURRENT_USER,
+                    hKey,
                     location,
                     this.name,
                 )

--- a/shared/auto-start/src/desktopMain/kotlin/ir/amirab/util/startup/WindowsStartupDesktop.kt
+++ b/shared/auto-start/src/desktopMain/kotlin/ir/amirab/util/startup/WindowsStartupDesktop.kt
@@ -25,11 +25,14 @@ class WindowsStartupDesktop(
 
     override fun uninstall() {
         try {
-            Advapi32Util.registryDeleteValue(
-                WinReg.HKEY_CURRENT_USER,
-                "Software\\Microsoft\\Windows\\CurrentVersion\\Run",
-                this.name,
-            )
+            val location = "Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+            if (Advapi32Util.registryValueExists(WinReg.HKEY_CURRENT_USER, location, this.name)) {
+                Advapi32Util.registryDeleteValue(
+                    WinReg.HKEY_CURRENT_USER,
+                    location,
+                    this.name,
+                )
+            }
         } catch (e: Exception) {
             e.printStackTrace()
         }


### PR DESCRIPTION
Check if the startup registry value exists under HKCU\Software\Microsoft\Windows\CurrentVersion\Run before attempting to delete it. This prevents a Win32Exception (ERROR_FILE_NOT_FOUND) when auto-start is disabled.