### PR TITLE
Assign category regardless of setting "Use Category By Default"

### DIFF
--- a/shared/app/src/commonMain/kotlin/com/abdownloadmanager/shared/pages/adddownload/single/BaseAddSingleDownloadComponent.kt
+++ b/shared/app/src/commonMain/kotlin/com/abdownloadmanager/shared/pages/adddownload/single/BaseAddSingleDownloadComponent.kt
@@ -272,23 +272,16 @@ abstract class BaseAddSingleDownloadComponent(
                     onDuplicateStrategy = onDuplicateStrategy.value.orDefault(),
                     context = EmptyContext
                 ),
-                categoryId = getCategoryIfUseCategoryIsOn()?.id
+                categoryId = selectedCategory.value?.id
             )
             onRequestClose()
         }
     }
 
-    private fun getCategoryIfUseCategoryIsOn(): Category? {
-        return if (useCategory.value)
-            selectedCategory.value
-        else
-            null
-    }
-
     private fun saveLocationIfNecessary(folder: String) {
-        val category = getCategoryIfUseCategoryIsOn()
+        val category = if (useCategory.value) selectedCategory.value else null
         val shouldAdd = if (category == null) {
-            // always add if user don't use category
+            // always add if user don't use category folder
             true
         } else {
             // only add if category path is not the same as provided path
@@ -316,7 +309,7 @@ abstract class BaseAddSingleDownloadComponent(
                     context = EmptyContext,
                 ),
                 queueId = queueId,
-                categoryId = getCategoryIfUseCategoryIsOn()?.id,
+                categoryId = selectedCategory.value?.id,
             ).invokeOnCompletion {
                 if (queueId != null && startQueue) {
                     GlobalScope.launch {


### PR DESCRIPTION
Issue #1353

Previously downloaded items were assigned a category if the toggle `Use Category By Default` is on. In this change, the files are assigned a category regardless of this setting.

Effect is that even with this toggle OFF, downloaded files on the right will be categorized based on which category is selected on the left pane.