### PR TITLE
Support composite HTTP downloads for multipart browser captures

### DIFF
--- a/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/di/Di.kt
+++ b/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/di/Di.kt
@@ -33,6 +33,7 @@ import com.abdownloadmanager.desktop.utils.proxy.DesktopSystemProxySelectorProvi
 import com.abdownloadmanager.desktop.utils.proxy.ProxyCachingConfig
 import com.abdownloadmanager.desktop.utils.renderapi.CustomRenderApi
 import com.abdownloadmanager.integration.model.HLSDownloadCredentialsFromIntegration
+import com.abdownloadmanager.integration.model.HttpBundleDownloadCredentialsFromIntegration
 import com.abdownloadmanager.integration.model.HttpDownloadCredentialsFromIntegration
 import com.abdownloadmanager.integration.model.IDownloadCredentialsFromIntegration
 import com.arkivanov.decompose.DefaultComponentContext
@@ -405,6 +406,10 @@ val jsonModule = module {
                     subclass(
                         HLSDownloadCredentialsFromIntegration::class,
                         HLSDownloadCredentialsFromIntegration.serializer()
+                    )
+                    subclass(
+                        HttpBundleDownloadCredentialsFromIntegration::class,
+                        HttpBundleDownloadCredentialsFromIntegration.serializer()
                     )
                     defaultDeserializer {
                         HttpDownloadCredentialsFromIntegration.serializer()

--- a/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/integration/IntegrationHandlerImp.kt
+++ b/desktop/app/src/main/kotlin/com/abdownloadmanager/desktop/integration/IntegrationHandlerImp.kt
@@ -14,6 +14,8 @@ import ir.amirab.downloader.NewDownloadItemProps
 import ir.amirab.downloader.downloaditem.EmptyContext
 import ir.amirab.downloader.downloaditem.hls.HLSDownloadCredentials
 import ir.amirab.downloader.downloaditem.http.HttpDownloadCredentials
+import ir.amirab.downloader.downloaditem.http.HttpDownloadBundle
+import ir.amirab.downloader.downloaditem.http.HttpDownloadBundleSource
 import ir.amirab.downloader.queue.QueueManager
 import ir.amirab.downloader.utils.OnDuplicateStrategy
 import org.koin.core.component.KoinComponent
@@ -105,6 +107,24 @@ class IntegrationHandlerImp : IntegrationHandler, KoinComponent {
                         link = it.link,
                         headers = it.headers,
                         downloadPage = it.downloadPage,
+                    )
+                }
+
+                is HttpBundleDownloadCredentialsFromIntegration -> {
+                    HttpDownloadCredentials(
+                        link = it.link,
+                        downloadPage = it.downloadPage,
+                        bundle = HttpDownloadBundle(
+                            sources = it.sources.map { source ->
+                                HttpDownloadBundleSource(
+                                    link = source.link,
+                                    headers = source.headers,
+                                    suggestedName = source.suggestedName,
+                                    contentLength = source.contentLength,
+                                )
+                            },
+                            suggestedName = it.suggestedName ?: "google-drive-download.zip",
+                        ),
                     )
                 }
             }

--- a/downloader/core/build.gradle.kts
+++ b/downloader/core/build.gradle.kts
@@ -21,8 +21,14 @@ kotlin {
                 api(libs.okio.okio)
                 api(libs.okhttp.okhttp)
                 api(libs.okhttp.coroutines)
+                implementation(libs.commons.compress)
                 implementation(project(":shared:utils"))
                 api("io.lindstrom:m3u8-parser:0.29")
+            }
+        }
+        named("desktopTest") {
+            dependencies {
+                implementation(kotlin("test"))
             }
         }
     }

--- a/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/destination/HttpBundleDownloadDestination.kt
+++ b/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/destination/HttpBundleDownloadDestination.kt
@@ -1,0 +1,140 @@
+package ir.amirab.downloader.destination
+
+import ir.amirab.downloader.downloaditem.http.HttpBundlePart
+import ir.amirab.downloader.part.DownloadPart
+import ir.amirab.downloader.part.PartDownloadStatus
+import ir.amirab.util.tryAtomicMove
+import okhttp3.internal.closeQuietly
+import okio.FileHandle
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
+import java.io.File
+
+class HttpBundleDownloadDestination(
+    outputFile: File,
+    private val tempDirectory: File,
+    private val downloadId: Long,
+    private val appendExtensionToIncompleteDownloads: Boolean,
+    private val getAllParts: () -> List<HttpBundlePart>,
+    private val assembler: ZipBundleAssembler = ZipBundleAssembler(),
+) : DownloadDestination(outputFile) {
+    val incompleteFile: File by lazy {
+        IncompleteFileUtil.addIncompleteIndicator(outputFile, downloadId)
+    }
+    private val archiveFile: File
+        get() = if (appendExtensionToIncompleteDownloads) incompleteFile else outputFile
+
+    private val handles = mutableMapOf<Long, FileHandle>()
+
+    fun getFileOfPart(part: HttpBundlePart): File = tempDirectory.resolve(part.index.toString())
+
+    fun syncPartsWithFiles(parts: List<HttpBundlePart>) {
+        tempDirectory.mkdirs()
+        parts.forEach { part ->
+            val file = getFileOfPart(part)
+            if (part.length == 0L && !file.exists()) {
+                file.createNewFile()
+            }
+            val validLength = file.length().takeIf { file.exists() && it <= part.length } ?: 0L
+            if (file.exists() && file.length() > part.length) {
+                file.delete()
+            }
+            part.current = validLength
+            part.statusFlow.value = if (part.isCompleted) {
+                PartDownloadStatus.Completed
+            } else {
+                PartDownloadStatus.IDLE
+            }
+        }
+    }
+
+    override fun getWriterFor(part: DownloadPart): DestWriter {
+        require(part is HttpBundlePart)
+        tempDirectory.mkdirs()
+        val file = getFileOfPart(part)
+        val handle = FileSystem.SYSTEM.openReadWrite(file.toOkioPath(), mustCreate = false, mustExist = false)
+        handle.resize(part.current)
+        synchronized(this) {
+            handles.remove(part.index)?.closeQuietly()
+            handles[part.index] = handle
+        }
+        return DestWriter(
+            id = part.index,
+            file = file,
+            seekPos = part.current,
+            writer = handle,
+        ).also {
+            synchronized(this) { fileParts.add(it) }
+        }
+    }
+
+    override fun onPartCancelled(part: DownloadPart) {
+        synchronized(this) {
+            handles.remove(part.getID())?.closeQuietly()
+        }
+        super.onPartCancelled(part)
+    }
+
+    override fun canGetFileWriter(): Boolean = true
+
+    override suspend fun prepareFile(onProgressUpdate: (Int?) -> Unit) {
+        DownloadDestination.prepareDestinationFolder(outputFile)
+        tempDirectory.mkdirs()
+    }
+
+    override suspend fun isDownloadedPartsIsValid(): Boolean = tempDirectory.exists()
+
+    override fun flush() {
+        synchronized(this) {
+            handles.values.forEach { runCatching { it.flush() } }
+        }
+    }
+
+    override fun onAllPartsCompleted(onProgressUpdate: (Int?) -> Unit) {
+        synchronized(this) {
+            if (allPartsDownloaded) {
+                return
+            }
+            closeHandles()
+            assembler.assemble(
+                parts = getAllParts(),
+                sourceFile = ::getFileOfPart,
+                destination = archiveFile,
+                onProgress = { onProgressUpdate(it) },
+            )
+            if (appendExtensionToIncompleteDownloads) {
+                outputFile.delete()
+                incompleteFile.tryAtomicMove(outputFile)
+            }
+            super.onAllPartsCompleted(onProgressUpdate)
+        }
+    }
+
+    override fun moveOutput(to: File) {
+        closeHandles()
+        if (appendExtensionToIncompleteDownloads && incompleteFile.exists()) {
+            incompleteFile.tryAtomicMove(IncompleteFileUtil.addIncompleteIndicator(to, downloadId))
+        }
+        super.moveOutput(to)
+    }
+
+    override fun deleteOutputFile() {
+        closeHandles()
+        incompleteFile.delete()
+        super.deleteOutputFile()
+    }
+
+    override fun cleanUpJunkFiles() {
+        closeHandles()
+        runCatching { FileSystem.SYSTEM.deleteRecursively(tempDirectory.toOkioPath()) }
+        incompleteFile.takeIf { it != outputFile }?.delete()
+    }
+
+    private fun closeHandles() {
+        synchronized(this) {
+            handles.values.forEach { it.closeQuietly() }
+            handles.clear()
+            fileParts.clear()
+        }
+    }
+}

--- a/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/destination/ZipBundleAssembler.kt
+++ b/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/destination/ZipBundleAssembler.kt
@@ -1,0 +1,72 @@
+package ir.amirab.downloader.destination
+
+import ir.amirab.downloader.downloaditem.http.HttpBundlePart
+import ir.amirab.downloader.utils.calcPercent
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
+import org.apache.commons.compress.archivers.zip.ZipFile
+import org.apache.commons.compress.archivers.zip.Zip64Mode
+import java.io.File
+import java.util.zip.ZipEntry
+
+class ZipBundleAssembler {
+    fun assemble(
+        parts: List<HttpBundlePart>,
+        sourceFile: (HttpBundlePart) -> File,
+        destination: File,
+        onProgress: (Int) -> Unit,
+    ) {
+        destination.parentFile?.mkdirs()
+        destination.delete()
+        val totalLength = parts.sumOf { it.length }.coerceAtLeast(1)
+        var processedLength = 0L
+        var lastProgress = -1
+
+        fun reportProgress() {
+            val progress = calcPercent(processedLength, totalLength)
+            if (progress != lastProgress) {
+                lastProgress = progress
+                onProgress(progress)
+            }
+        }
+
+        ZipArchiveOutputStream(destination).use { output ->
+            output.setUseZip64(Zip64Mode.AsNeeded)
+            parts.sortedBy { it.index }.forEach { part ->
+                val file = sourceFile(part)
+                require(file.isFile && file.length() == part.length) {
+                    "bundle source is missing or incomplete: ${part.source.suggestedName}"
+                }
+                if (part.source.suggestedName.endsWith(".zip", ignoreCase = true)) {
+                    copyZipEntries(file, output)
+                } else {
+                    val entry = output.createArchiveEntry(file, part.source.suggestedName) as ZipArchiveEntry
+                    entry.method = ZipEntry.STORED
+                    output.putArchiveEntry(entry)
+                    file.inputStream().buffered().use { input ->
+                        input.copyTo(output)
+                    }
+                    output.closeArchiveEntry()
+                }
+                processedLength += part.length
+                reportProgress()
+            }
+            output.finish()
+        }
+        onProgress(100)
+    }
+
+    private fun copyZipEntries(source: File, output: ZipArchiveOutputStream) {
+        ZipFile.builder().setFile(source).get().use { input ->
+            val entries = input.entries
+            while (entries.hasMoreElements()) {
+                val entry = entries.nextElement()
+                val rawInput = input.getRawInputStream(entry)
+                    ?: error("can't read ZIP entry ${entry.name}")
+                rawInput.use {
+                    output.addRawArchiveEntry(ZipArchiveEntry(entry), it)
+                }
+            }
+        }
+    }
+}

--- a/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpBundleDownloadJob.kt
+++ b/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpBundleDownloadJob.kt
@@ -1,0 +1,277 @@
+package ir.amirab.downloader.downloaditem.http
+
+import ir.amirab.downloader.DownloadManager
+import ir.amirab.downloader.connection.HttpDownloaderClient
+import ir.amirab.downloader.destination.DownloadDestination
+import ir.amirab.downloader.destination.HttpBundleDownloadDestination
+import ir.amirab.downloader.downloaditem.DownloadJob
+import ir.amirab.downloader.downloaditem.DownloadJobExtraConfig
+import ir.amirab.downloader.downloaditem.DownloadJobStatus
+import ir.amirab.downloader.downloaditem.DownloadStatus
+import ir.amirab.downloader.downloaditem.IDownloadItem
+import ir.amirab.downloader.part.PartDownloadStatus
+import ir.amirab.downloader.utils.speedlimiter.SpeedLimiter
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentHashMap
+
+class HttpBundleDownloadJob(
+    override val downloadItem: HttpDownloadItem,
+    downloadManager: DownloadManager,
+    private val client: HttpDownloaderClient,
+) : DownloadJob(downloadManager) {
+    private val bundle = requireNotNull(downloadItem.bundle)
+    private val listDb by downloadManager::dlListDb
+    private val parts = bundle.sources.mapIndexed { index, source ->
+        HttpBundlePart(index.toLong(), source)
+    }
+    private lateinit var destination: HttpBundleDownloadDestination
+    private val itemSaveLock = Mutex()
+    private val partLoopLock = Mutex()
+    private val jobThrottler = SpeedLimiter()
+    private val partDownloaders = ConcurrentHashMap<Long, HttpBundlePartDownloader>()
+    private val listenerJobs = ConcurrentHashMap<Long, Job>()
+    private var lastSavedDownloadItem: HttpDownloadItem? = null
+
+    override fun getDestination(): DownloadDestination = destination
+
+    fun getParts(): List<HttpBundlePart> = parts.toList()
+
+    override suspend fun actualBoot() {
+        initializeDestination()
+        destination.syncPartsWithFiles(parts)
+        downloadItem.contentLength = bundle.totalContentLength
+        applySpeedLimit()
+    }
+
+    override fun initializeDestination() {
+        destination = HttpBundleDownloadDestination(
+            outputFile = downloadManager.calculateOutputFile(downloadItem),
+            tempDirectory = downloadManager.downloadDataFolder.resolve(id.toString()).resolve("http-bundle"),
+            downloadId = id,
+            appendExtensionToIncompleteDownloads = downloadManager.settings.appendExtensionToIncompleteDownloads,
+            getAllParts = ::getParts,
+        )
+    }
+
+    override suspend fun reset() {
+        pause()
+        clearPartDownloaderList()
+        destination.cleanUpJunkFiles()
+        destination.deleteOutputFile()
+        parts.forEach(HttpBundlePart::resetCurrent)
+        downloadItem.contentLength = bundle.totalContentLength
+        downloadItem.status = DownloadStatus.Added
+        downloadItem.startTime = null
+        downloadItem.completeTime = null
+        saveState()
+        downloadManager.onDownloadItemChange(downloadItem)
+    }
+
+    override suspend fun resume() {
+        if (isDownloadActive.value) {
+            return
+        }
+        _isDownloadActive.update { true }
+        resumeWithNewScope(createAndInitializeDownloadScope())
+    }
+
+    private fun createAndInitializeDownloadScope(): CoroutineScope {
+        return newScopeBasedOn(scope).also { activeDownloadScope = it }
+    }
+
+    private suspend fun resumeWithNewScope(newActiveScope: CoroutineScope) {
+        newActiveScope.launch {
+            boot()
+            destination.syncPartsWithFiles(parts)
+            if (parts.all { it.isCompleted }) {
+                onDownloadFinished()
+                return@launch
+            }
+            onDownloadResuming()
+            try {
+                destination.prepareFile { _status.value = DownloadJobStatus.PreparingFile(it) }
+                createPartDownloaderList()
+                beginDownloadParts()
+                startAutoSaver()
+                downloadItem.status = DownloadStatus.Downloading
+                if (downloadItem.startTime == null) {
+                    downloadItem.startTime = System.currentTimeMillis()
+                }
+                saveState()
+                onDownloadResumed()
+            } catch (error: Exception) {
+                scope.launch { pause(error) }
+            }
+        }.join()
+    }
+
+    override fun getDownloadedSize(): Long = parts.sumOf(HttpBundlePart::howMuchProceed)
+
+    private fun getRequestedThreadCount(): Int {
+        return (downloadItem.preferredConnectionCount
+            ?: downloadManager.settings.defaultThreadCount).coerceAtLeast(1)
+    }
+
+    private fun beginDownloadParts() {
+        if (partLoopLock.isLocked) {
+            return
+        }
+        activeDownloadScope?.launch {
+            if (!partLoopLock.tryLock()) {
+                return@launch
+            }
+            try {
+                val active = partDownloaders.values.filter { it.active }
+                val countToStart = getRequestedThreadCount() - active.size
+                if (countToStart > 0) {
+                    partDownloaders.values
+                        .filter { !it.active && !it.part.isCompleted }
+                        .sortedBy { it.part.index }
+                        .take(countToStart)
+                        .forEach(HttpBundlePartDownloader::start)
+                } else if (countToStart < 0) {
+                    active.sortedByDescending { it.part.index }
+                        .take(-countToStart)
+                        .onEach(HttpBundlePartDownloader::stop)
+                        .forEach {
+                            it.join()
+                            it.awaitIdle()
+                        }
+                }
+            } finally {
+                partLoopLock.unlock()
+            }
+        }
+    }
+
+    private fun createPartDownloaderList() {
+        synchronized(partDownloaders) {
+            parts.forEach(::getOrCreatePartDownloader)
+        }
+    }
+
+    private fun getOrCreatePartDownloader(part: HttpBundlePart): HttpBundlePartDownloader {
+        return partDownloaders.getOrPut(part.index) {
+            HttpBundlePartDownloader(
+                part = part,
+                getDestWriter = { destination.getWriterFor(part) },
+                credentials = part.source.asCredentials(downloadItem.downloadPage),
+                client = client,
+                speedLimiters = listOf(downloadManager.speedLimiter, jobThrottler),
+            ).also { downloader ->
+                downloader.onTooManyErrors = { error ->
+                    scope.launch { pause(error) }
+                }
+                listenerJobs[part.index] = downloader.statusFlow.onEach { status ->
+                    onPartStatusChanged(downloader, status)
+                }.launchIn(scope)
+            }
+        }
+    }
+
+    private fun onPartStatusChanged(
+        downloader: HttpBundlePartDownloader,
+        status: PartDownloadStatus,
+    ) {
+        when (status) {
+            is PartDownloadStatus.Canceled -> destination.onPartCancelled(downloader.part)
+            PartDownloadStatus.Completed -> scope.launch {
+                destination.onPartCancelled(downloader.part)
+                if (parts.all { it.isCompleted }) {
+                    onDownloadFinished()
+                } else {
+                    beginDownloadParts()
+                }
+            }
+            PartDownloadStatus.ReceivingData,
+            PartDownloadStatus.Connecting,
+            PartDownloadStatus.IDLE -> Unit
+        }
+    }
+
+    private fun clearPartDownloaderList() {
+        listenerJobs.values.forEach(Job::cancel)
+        listenerJobs.clear()
+        partDownloaders.clear()
+    }
+
+    private suspend fun stopAllParts() {
+        withContext(Dispatchers.IO) {
+            partDownloaders.values.onEach(HttpBundlePartDownloader::stop).onEach {
+                it.join()
+                it.awaitIdle()
+            }
+        }
+    }
+
+    private suspend fun cancelDownloadScope() {
+        activeDownloadScope?.coroutineContext?.job?.cancelAndJoin()
+        activeDownloadScope = null
+    }
+
+    override suspend fun pause(throwable: Throwable) {
+        boot()
+        cancelDownloadScope()
+        stopAllParts()
+        onDownloadCanceled(throwable)
+    }
+
+    override suspend fun changeConfig(
+        updater: (IDownloadItem) -> Unit,
+        extraConfig: DownloadJobExtraConfig?,
+    ): IDownloadItem {
+        boot()
+        val previousItem = downloadItem.copy()
+        val newItem = previousItem.copy().apply(updater)
+        val previousOutput = downloadManager.calculateOutputFile(previousItem)
+        val newOutput = downloadManager.calculateOutputFile(newItem)
+        val outputChanged = previousOutput != newOutput
+        if (outputChanged) {
+            if (isDownloadActive.value) {
+                pause(CancellationException())
+            }
+            destination.moveOutput(newOutput)
+        }
+        downloadItem.applyFrom(newItem)
+        if (outputChanged) {
+            initializeDestination()
+        }
+        applySpeedLimit()
+        saveState()
+        return downloadItem
+    }
+
+    private fun applySpeedLimit() {
+        jobThrottler.bytesPerSecond(downloadItem.speedLimit)
+    }
+
+    override suspend fun saveState() {
+        destination.flush()
+        itemSaveLock.withLock {
+            val copy = downloadItem.copy()
+            if (copy != lastSavedDownloadItem) {
+                listDb.update(downloadItem)
+                lastSavedDownloadItem = copy
+            }
+        }
+    }
+
+    override fun reloadSettings() {
+        applySpeedLimit()
+        beginDownloadParts()
+    }
+
+    override suspend fun extraConfigsReceived(config: DownloadJobExtraConfig) = Unit
+}

--- a/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpBundlePart.kt
+++ b/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpBundlePart.kt
@@ -1,0 +1,31 @@
+package ir.amirab.downloader.downloaditem.http
+
+import ir.amirab.downloader.part.DownloadPart
+import ir.amirab.downloader.part.PartDownloadStatus
+import ir.amirab.downloader.utils.calcPercent
+import kotlinx.coroutines.flow.MutableStateFlow
+
+data class HttpBundlePart(
+    val index: Long,
+    val source: HttpDownloadBundleSource,
+    @Volatile override var current: Long = 0,
+) : DownloadPart {
+    val length: Long get() = source.contentLength
+
+    override val statusFlow = MutableStateFlow<PartDownloadStatus>(PartDownloadStatus.IDLE)
+
+    override val isCompleted: Boolean
+        get() = current == length
+
+    override val percent: Int
+        get() = if (length == 0L) 100 else calcPercent(current, length)
+
+    override fun howMuchProceed(): Long = current
+
+    override fun resetCurrent() {
+        current = 0
+        statusFlow.value = PartDownloadStatus.IDLE
+    }
+
+    override fun getID(): Long = index
+}

--- a/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpBundlePartDownloader.kt
+++ b/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpBundlePartDownloader.kt
@@ -1,0 +1,77 @@
+package ir.amirab.downloader.downloaditem.http
+
+import ir.amirab.downloader.connection.Connection
+import ir.amirab.downloader.connection.HttpDownloaderClient
+import ir.amirab.downloader.connection.response.HttpResponseInfo
+import ir.amirab.downloader.connection.response.expectSuccess
+import ir.amirab.downloader.destination.DestWriter
+import ir.amirab.downloader.exception.ServerPartIsNotTheSameAsWeExpectException
+import ir.amirab.downloader.part.PartDownloader
+import ir.amirab.downloader.utils.speedlimiter.SpeedLimiter
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+import okio.Source
+import kotlin.math.min
+
+class HttpBundlePartDownloader(
+    part: HttpBundlePart,
+    getDestWriter: () -> DestWriter,
+    private val credentials: HttpDownloadCredentials,
+    private val client: HttpDownloaderClient,
+    private val speedLimiters: List<SpeedLimiter>,
+) : PartDownloader<HttpBundlePart>(part, getDestWriter) {
+
+    override fun howMuchCanRead(maxAllowed: Long): Long {
+        return min(maxAllowed, (part.length - part.current).coerceAtLeast(0))
+    }
+
+    override suspend fun connectAndVerify(): Connection<HttpResponseInfo> {
+        val requestedStart = part.current
+        val requestedEnd = part.length - 1
+        val connection = client.connect(credentials, requestedStart, requestedEnd)
+        runCatching { connection.responseInfo.expectSuccess() }
+            .onFailure { runCatching { connection.close() } }
+            .getOrThrow()
+
+        if (stop || !currentCoroutineContext().isActive) {
+            connection.close()
+            throw CancellationException()
+        }
+
+        val expectedLength = part.length - requestedStart
+        val actualLength = connection.contentLength.takeIf { it >= 0 }
+        val startsAtRequestedByte = connection.responseInfo.contentRange
+            ?.range
+            ?.first == requestedStart
+        if (actualLength != expectedLength && !startsAtRequestedByte) {
+            connection.close()
+            throw ServerPartIsNotTheSameAsWeExpectException(
+                start = requestedStart,
+                end = requestedEnd,
+                expectedLength = expectedLength,
+                actualLength = actualLength,
+            )
+        }
+
+        val limitedSource = speedLimiters.fold<SpeedLimiter, Source>(connection.source) { source, limiter ->
+            limiter.source(source)
+        }
+        return connection.copy(source = limitedSource)
+    }
+
+    override fun onFinish() {
+        if (part.isCompleted) {
+            super.onFinish()
+        } else {
+            onCanceled(
+                ServerPartIsNotTheSameAsWeExpectException(
+                    start = part.current,
+                    end = part.length - 1,
+                    expectedLength = part.length - part.current,
+                    actualLength = 0,
+                )
+            )
+        }
+    }
+}

--- a/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpDownloadBundle.kt
+++ b/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpDownloadBundle.kt
@@ -1,0 +1,48 @@
+package ir.amirab.downloader.downloaditem.http
+
+import ir.amirab.util.HttpUrlUtils
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HttpDownloadBundleSource(
+    val link: String,
+    val headers: Map<String, String>? = null,
+    val suggestedName: String,
+    val contentLength: Long,
+) {
+    fun validate() {
+        require(HttpUrlUtils.isValidUrl(link)) { "bundle source URL is not valid" }
+        require(suggestedName.isNotBlank()) { "bundle source name is blank" }
+        require(contentLength >= 0) {
+            "bundle source length is invalid"
+        }
+    }
+
+    fun asCredentials(downloadPage: String?): HttpDownloadCredentials {
+        return HttpDownloadCredentials(
+            link = link,
+            headers = headers,
+            downloadPage = downloadPage,
+        )
+    }
+}
+
+@Serializable
+data class HttpDownloadBundle(
+    val sources: List<HttpDownloadBundleSource>,
+    val suggestedName: String,
+) {
+    val totalContentLength: Long
+        get() {
+            return sources.fold(0L) { total, source ->
+                Math.addExact(total, source.contentLength)
+            }
+        }
+
+    fun validate() {
+        require(sources.size > 1) { "an HTTP bundle must contain at least two sources" }
+        require(suggestedName.isNotBlank()) { "bundle name is blank" }
+        sources.forEach(HttpDownloadBundleSource::validate)
+        totalContentLength
+    }
+}

--- a/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpDownloadCredentials.kt
+++ b/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpDownloadCredentials.kt
@@ -16,6 +16,7 @@ data class HttpDownloadCredentials(
     override val password: String? = null,
     override val downloadPage: String? = null,
     override val userAgent: String? = null,
+    val bundle: HttpDownloadBundle? = null,
 ) : IHttpDownloadCredentials {
     override fun validateCredentials() {
         validate(this)
@@ -40,6 +41,15 @@ data class HttpDownloadCredentials(
             credentials.run {
                 return when (this) {
                     is HttpDownloadCredentials -> this
+                    is HttpDownloadItem -> HttpDownloadCredentials(
+                        link = link,
+                        headers = headers,
+                        username = username,
+                        password = password,
+                        downloadPage = downloadPage,
+                        userAgent = userAgent,
+                        bundle = bundle,
+                    )
                     else -> HttpDownloadCredentials(
                         link = link,
                         headers = headers,
@@ -57,6 +67,11 @@ data class HttpDownloadCredentials(
             require(HttpUrlUtils.isValidUrl(credentials.link)) {
                 "url is not valid"
             }
+            when (credentials) {
+                is HttpDownloadCredentials -> credentials.bundle
+                is HttpDownloadItem -> credentials.bundle
+                else -> null
+            }?.validate()
         }
     }
 }

--- a/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpDownloadItem.kt
+++ b/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpDownloadItem.kt
@@ -20,6 +20,7 @@ data class HttpDownloadItem(
     override var userAgent: String? = null,
 
     var serverETag: String? = null,
+    var bundle: HttpDownloadBundle? = null,
 
 //    IDownloadItem
     override var id: Long,
@@ -136,6 +137,7 @@ data class HttpDownloadItem(
                 name = name,
                 contentLength = contentLength,
                 serverETag = serverETag,
+                bundle = credentials.bundle,
                 dateAdded = dateAdded,
                 startTime = startTime,
                 completeTime = completeTime,
@@ -163,6 +165,7 @@ fun HttpDownloadItem.applyFrom(other: HttpDownloadItem) {
 
     contentLength = other.contentLength
     serverETag = other.serverETag
+    bundle = other.bundle
 
     dateAdded = other.dateAdded
     startTime = other.startTime
@@ -181,5 +184,6 @@ fun HttpDownloadItem.withHttpCredentials(credentials: IHttpDownloadCredentials) 
     password = credentials.password
     downloadPage = credentials.downloadPage
     userAgent = credentials.userAgent
+    bundle = (credentials as? HttpDownloadCredentials)?.bundle
 }
 

--- a/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpDownloader.kt
+++ b/downloader/core/src/commonMain/kotlin/ir/amirab/downloader/downloaditem/http/HttpDownloader.kt
@@ -3,23 +3,24 @@ package ir.amirab.downloader.downloaditem.http
 import ir.amirab.downloader.DownloadManager
 import ir.amirab.downloader.Downloader
 import ir.amirab.downloader.connection.HttpDownloaderClient
+import ir.amirab.downloader.downloaditem.DownloadJob
 import ir.amirab.downloader.downloaditem.IDownloadItem
 import kotlinx.serialization.KSerializer
 import kotlin.reflect.KClass
 
 class HttpDownloader(
     httpDownloaderClient: Lazy<HttpDownloaderClient>
-) : Downloader<HttpDownloadItem, HttpDownloadJob, HttpDownloadCredentials> {
+) : Downloader<HttpDownloadItem, DownloadJob, HttpDownloadCredentials> {
     val httpDownloaderClient by httpDownloaderClient
     override fun createJob(
         item: HttpDownloadItem,
         downloadManager: DownloadManager,
-    ): HttpDownloadJob {
-        return HttpDownloadJob(
-            item,
-            downloadManager,
-            httpDownloaderClient,
-        )
+    ): DownloadJob {
+        return if (item.bundle == null) {
+            HttpDownloadJob(item, downloadManager, httpDownloaderClient)
+        } else {
+            HttpBundleDownloadJob(item, downloadManager, httpDownloaderClient)
+        }
     }
 
     override fun accept(item: IDownloadItem): Boolean {
@@ -28,7 +29,7 @@ class HttpDownloader(
 
     override val downloadItemClass: KClass<HttpDownloadItem> = HttpDownloadItem::class
     override val downloadCredentialsClass: KClass<HttpDownloadCredentials> = HttpDownloadCredentials::class
-    override val downloadJobClass: KClass<HttpDownloadJob> = HttpDownloadJob::class
+    override val downloadJobClass: KClass<DownloadJob> = DownloadJob::class
     override val downloadItemSerializer: KSerializer<HttpDownloadItem> = HttpDownloadItem.serializer()
     override val downloadCredentialsSerializer: KSerializer<HttpDownloadCredentials> =
         HttpDownloadCredentials.serializer()

--- a/downloader/core/src/desktopTest/kotlin/ir/amirab/downloader/destination/ZipBundleAssemblerTest.kt
+++ b/downloader/core/src/desktopTest/kotlin/ir/amirab/downloader/destination/ZipBundleAssemblerTest.kt
@@ -1,0 +1,78 @@
+package ir.amirab.downloader.destination
+
+import ir.amirab.downloader.downloaditem.http.HttpBundlePart
+import ir.amirab.downloader.downloaditem.http.HttpDownloadBundleSource
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ZipBundleAssemblerTest {
+    @Test
+    fun mergesZipEntriesAndPlainFilesIntoOneArchive() {
+        val directory = createTempDirectory("abdm-zip-bundle-test").toFile()
+        try {
+            val firstZip = directory.resolve("first.zip")
+            val secondZip = directory.resolve("second.zip")
+            val video = directory.resolve("video.mp4").apply {
+                writeBytes(byteArrayOf(1, 2, 3, 4, 5))
+            }
+            createZip(firstZip, "folder/first.txt", "first".encodeToByteArray())
+            createZip(secondZip, "folder/second.txt", "second".encodeToByteArray())
+
+            val inputs = listOf(firstZip, secondZip, video)
+            val parts = inputs.mapIndexed { index, file ->
+                HttpBundlePart(
+                    index = index.toLong(),
+                    source = HttpDownloadBundleSource(
+                        link = "https://example.test/$index",
+                        suggestedName = file.name,
+                        contentLength = file.length(),
+                    ),
+                    current = file.length(),
+                )
+            }
+            val output = directory.resolve("merged.zip")
+            var progress = 0
+
+            ZipBundleAssembler().assemble(
+                parts = parts,
+                sourceFile = { inputs[it.index.toInt()] },
+                destination = output,
+                onProgress = { progress = it },
+            )
+
+            assertEquals(100, progress)
+            assertTrue(output.isFile)
+            ZipFile(output).use { zip ->
+                assertContentEquals(
+                    "first".encodeToByteArray(),
+                    zip.getInputStream(zip.getEntry("folder/first.txt")).readBytes(),
+                )
+                assertContentEquals(
+                    "second".encodeToByteArray(),
+                    zip.getInputStream(zip.getEntry("folder/second.txt")).readBytes(),
+                )
+                assertContentEquals(
+                    video.readBytes(),
+                    zip.getInputStream(zip.getEntry("video.mp4")).readBytes(),
+                )
+            }
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    private fun createZip(file: File, name: String, contents: ByteArray) {
+        ZipOutputStream(file.outputStream()).use { output ->
+            output.putNextEntry(ZipEntry(name))
+            output.write(contents)
+            output.closeEntry()
+        }
+    }
+}

--- a/downloader/core/src/desktopTest/kotlin/ir/amirab/downloader/downloaditem/http/HttpDownloadCredentialsTest.kt
+++ b/downloader/core/src/desktopTest/kotlin/ir/amirab/downloader/downloaditem/http/HttpDownloadCredentialsTest.kt
@@ -1,0 +1,31 @@
+package ir.amirab.downloader.downloaditem.http
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HttpDownloadCredentialsTest {
+    @Test
+    fun preservesBundleWhenCreatedFromDownloadItem() {
+        val bundle = HttpDownloadBundle(
+            sources = listOf(
+                HttpDownloadBundleSource(
+                    link = "https://example.test/archive-001.zip",
+                    suggestedName = "archive-001.zip",
+                    contentLength = 42,
+                ),
+            ),
+            suggestedName = "archive.zip",
+        )
+        val item = HttpDownloadItem.createWithCredentials(
+            credentials = HttpDownloadCredentials(
+                link = bundle.sources.first().link,
+                bundle = bundle,
+            ),
+            id = 1,
+            folder = ".",
+            name = bundle.suggestedName,
+        )
+
+        assertEquals(bundle, HttpDownloadCredentials.from(item).bundle)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ skiko = "0.144.6"
 kotlin-serialization = "1.11.0"
 okhttp = "5.4.0"
 okio = "3.18.0"
+commonsCompress = "1.28.0"
 coroutines = "1.11.0"
 koin = "4.2.2"
 koinAnnotation = "4.2.2"
@@ -58,6 +59,7 @@ okhttp-loggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor
 okhttp-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-coroutines = { module = "com.squareup.okhttp3:okhttp-coroutines", version.ref = "okhttp" }
 okio-okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commonsCompress" }
 
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }

--- a/integration/server/src/main/kotlin/com/abdownloadmanager/integration/model/DownloadCredentialsFromIntegration.kt
+++ b/integration/server/src/main/kotlin/com/abdownloadmanager/integration/model/DownloadCredentialsFromIntegration.kt
@@ -22,6 +22,23 @@ data class HttpDownloadCredentialsFromIntegration(
     override val suggestedName: String? = null,
 ) : IDownloadCredentialsFromIntegration
 
+@Serializable
+data class HttpDownloadBundleSourceFromIntegration(
+    val link: String,
+    val headers: Map<String, String>? = null,
+    val suggestedName: String,
+    val contentLength: Long,
+)
+
+@SerialName("http-bundle")
+@Serializable
+data class HttpBundleDownloadCredentialsFromIntegration(
+    override val link: String,
+    val sources: List<HttpDownloadBundleSourceFromIntegration>,
+    override val downloadPage: String? = null,
+    override val suggestedName: String? = null,
+) : IDownloadCredentialsFromIntegration
+
 @SerialName("hls")
 @Serializable
 data class HLSDownloadCredentialsFromIntegration(

--- a/shared/app/src/commonMain/kotlin/com/abdownloadmanager/shared/downloaderinui/http/HttpDownloaderInUi.kt
+++ b/shared/app/src/commonMain/kotlin/com/abdownloadmanager/shared/downloaderinui/http/HttpDownloaderInUi.kt
@@ -12,7 +12,9 @@ import com.abdownloadmanager.shared.downloaderinui.http.edit.HttpEditDownloadInp
 import com.abdownloadmanager.shared.util.SizeAndSpeedUnitProvider
 import com.abdownloadmanager.shared.util.DownloadSystem
 import ir.amirab.downloader.connection.response.HttpResponseInfo
+import ir.amirab.downloader.downloaditem.DownloadJob
 import ir.amirab.downloader.downloaditem.IDownloadCredentials
+import ir.amirab.downloader.downloaditem.http.HttpBundleDownloadJob
 import ir.amirab.downloader.downloaditem.http.HttpDownloadCredentials
 import ir.amirab.downloader.downloaditem.http.HttpDownloadItem
 import ir.amirab.downloader.downloaditem.http.HttpDownloadJob
@@ -31,7 +33,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 class HttpDownloaderInUi(
     httpDownloader: HttpDownloader,
     private val sizeAndSpeedUnitProvider: SizeAndSpeedUnitProvider,
-) : DownloaderInUi<HttpDownloadCredentials, HttpResponseInfo, DownloadSize.Bytes, HttpLinkChecker, HttpDownloadItem, HttpNewDownloadInputs, HttpEditDownloadInputs, HttpCredentialsToItemMapper, HttpDownloadJob, HttpDownloader>(
+) : DownloaderInUi<HttpDownloadCredentials, HttpResponseInfo, DownloadSize.Bytes, HttpLinkChecker, HttpDownloadItem, HttpNewDownloadInputs, HttpEditDownloadInputs, HttpCredentialsToItemMapper, DownloadJob, HttpDownloader>(
     downloader = httpDownloader
 ) {
     override fun createLinkChecker(initialCredentials: HttpDownloadCredentials): HttpLinkChecker {
@@ -110,13 +112,40 @@ class HttpDownloaderInUi(
     }
 
     override fun createProcessingDownloadItemState(
-        props: ProcessingDownloadItemFactoryInputs<HttpDownloadJob>
+        props: ProcessingDownloadItemFactoryInputs<DownloadJob>
     ): ProcessingDownloadItemState {
         val downloadJob = props.downloadJob
         val downloadItem = downloadJob.downloadItem
         val downloadJobStatus = downloadJob.status.value
-        val parts = downloadJob.getParts()
         val contentLength = downloadItem.contentLength
+        val (parts, supportResume) = when (downloadJob) {
+            is HttpDownloadJob -> {
+                downloadJob.getParts().map {
+                    UiRangedPart.fromPart(
+                        part = it,
+                        totalLength = contentLength,
+                    )
+                } to downloadJob.supportsConcurrent
+            }
+
+            is HttpBundleDownloadJob -> {
+                downloadJob.getParts().map { part ->
+                    UiRangedPart(
+                        id = part.index,
+                        status = part.status,
+                        howMuchProceed = part.howMuchProceed(),
+                        percent = part.percent,
+                        length = part.length,
+                        partSpace = when {
+                            contentLength <= 0 || part.length <= 0 -> 0f
+                            else -> (part.length.toDouble() / contentLength.toDouble()).toFloat()
+                        },
+                    )
+                } to true
+            }
+
+            else -> error("Unsupported HTTP download job: ${downloadJob::class.qualifiedName}")
+        }
         return RangeBasedProcessingDownloadItemState(
             id = downloadItem.id,
             folder = downloadItem.folder,
@@ -127,14 +156,9 @@ class HttpDownloaderInUi(
             completeTime = downloadItem.completeTime ?: -1,
             status = downloadJobStatus,
             saveLocation = downloadItem.name,
-            parts = parts.map {
-                UiRangedPart.fromPart(
-                    part = it,
-                    totalLength = contentLength,
-                )
-            },
+            parts = parts,
             speed = props.speed,
-            supportResume = downloadJob.supportsConcurrent,
+            supportResume = supportResume,
             downloadLink = downloadItem.link,
             isWaiting = props.isWaiting,
         )

--- a/shared/app/src/commonMain/kotlin/com/abdownloadmanager/shared/downloaderinui/http/add/HttpLinkChecker.kt
+++ b/shared/app/src/commonMain/kotlin/com/abdownloadmanager/shared/downloaderinui/http/add/HttpLinkChecker.kt
@@ -29,15 +29,26 @@ class HttpLinkChecker(
     }
 
     override suspend fun actualCheck(credentials: HttpDownloadCredentials): HttpResponseInfo {
-        return client.test(credentials)
+        val credentialsToCheck = credentials.bundle
+            ?.sources
+            ?.firstOrNull()
+            ?.asCredentials(credentials.downloadPage)
+            ?: credentials
+        return client.test(credentialsToCheck)
     }
 
     private fun updateNameAndLength(responseInfo: HttpResponseInfo?) {
-        val suggestedName = responseInfo
-            ?.fileName ?: HttpUrlUtils.extractNameFromLink(credentials.value.link)
-            ?.let(FilenameFixer::fix)
-        val length = responseInfo?.run {
-            totalLength.takeIf { isSuccessFul }
+        val currentCredentials = credentials.value
+        val bundle = currentCredentials.bundle
+        val suggestedName = bundle?.suggestedName?.let(FilenameFixer::fix)
+            ?: responseInfo?.fileName
+            ?: HttpUrlUtils.extractNameFromLink(currentCredentials.link)?.let(FilenameFixer::fix)
+        val length = if (bundle != null) {
+            bundle.totalContentLength.takeIf { it >= 0 }
+        } else {
+            responseInfo?.run {
+                totalLength.takeIf { isSuccessFul }
+            }
         }
         _suggestedName.update { suggestedName }
         _length.update { length }


### PR DESCRIPTION
### Summary

- Add an http-bundle integration payload and persist its source metadata with HTTP download items.
- Represent the bundle as one item with aggregate size and per-source resume state.
- Download source responses concurrently using the item's preferred connection count or the configured default.
- Assemble one Zip64 output, raw-copying entries from ZIP sources and storing standalone files without recompression.
- Display bundle sources as parts of the single download in the UI.

### Testing

- Real Google Drive archive: 13 browser responses became one dialog, one download item, and one final ZIP.
- Synthetic integration: two ZIP sources plus one standalone file produced one valid archive.
- :downloader:core:desktopTest — 2 tests passed.
- :desktop:app:compileKotlin — passed.

Related discussion: #1359
Companion browser-integration PR: https://github.com/amir1376/ab-download-manager-browser-integration/pull/66

### Notes

This payload requires the coordinated browser-integration change. Source temporary files are removed after successful assembly; while assembling, disk usage can temporarily include both the source parts and final archive.